### PR TITLE
fix: typos error

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,6 @@ spring:
 #  level:
 #    root: WARN
 #    org:
-#      Springframework:
+#      springframework:
 #        security: DEBUG
 #    org.springframework.security: DEBUG


### PR DESCRIPTION
logging日志的配置中，包路径该为org.springframework.security，所以springframework包名不应该大写